### PR TITLE
config 처리 시 AWS secrets manager 지원

### DIFF
--- a/crypt/aws_secret_manager.go
+++ b/crypt/aws_secret_manager.go
@@ -1,0 +1,75 @@
+package crypt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	log "github.com/fatima-go/fatima-log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+type AWSSecretManager struct {
+	config    aws.Config
+	client    *secretsmanager.Client
+	secretMap map[string]string
+	secretID  string
+}
+
+func NewAWSSecretManager() *AWSSecretManager {
+	return &AWSSecretManager{}
+}
+
+func (sm *AWSSecretManager) SetSecretID(id string) {
+	sm.secretID = id
+}
+
+func (sm *AWSSecretManager) SetAWSConfig(cfg aws.Config) {
+	sm.config = cfg
+}
+
+func (sm *AWSSecretManager) GetSecretValue(key string) string {
+	val, found := sm.secretMap[key]
+	if !found {
+		log.Error("key not found in secret cache [key: %s]", key)
+	}
+
+	return val
+}
+
+func (sm *AWSSecretManager) createAWSClient() error {
+	if sm.config.Region == "" {
+		cfg, err := config.LoadDefaultConfig(context.Background())
+		if err != nil {
+			return err
+		}
+
+		sm.config = cfg
+	}
+
+	sm.client = secretsmanager.NewFromConfig(sm.config)
+	return nil
+}
+
+func (sm *AWSSecretManager) CacheSecretValues() error {
+	if sm.secretID == "" {
+		return errors.New("secret ID is not specified")
+	}
+
+	err := sm.createAWSClient()
+	if err != nil {
+		return err
+	}
+
+	secret, err := sm.client.GetSecretValue(context.Background(),
+		&secretsmanager.GetSecretValueInput{
+			SecretId: aws.String(sm.secretID),
+		})
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal([]byte(*secret.SecretString), &sm.secretMap)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,9 @@ module github.com/fatima-go/fatima-core
 go 1.17
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.20.1
+	github.com/aws/aws-sdk-go-v2/config v1.18.33
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.21.0
 	github.com/fatima-go/fatima-log v1.0.0
 	github.com/robfig/cron v1.2.0
 	github.com/stretchr/testify v1.8.2
@@ -12,6 +15,16 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/credentials v1.13.32 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.8 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.38 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.32 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.39 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.32 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.13.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.21.2 // indirect
+	github.com/aws/smithy-go v1.14.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getsentry/sentry-go v0.20.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect


### PR DESCRIPTION
Config 처리 시 AWS secrets manager를 지원하도록 작업한 Draft PR입니다.
AWS SDK를 사용하여 작성되었으며 분기 브랜치는 `enhancement/secret_support` 입니다.

(해당 소스는 컨셉 코드로 merge 계획이 없습니다.)

cf. https://github.com/fatima-go/fatima-core/issues/1