### PR TITLE
[ISSUE-3] 알람 전송 > 직접 프로세스 종료 처리 시 알람 무시 가능 여부, 배포 등을 통해 프로세스 구동 시 관련 정보를 알 수 있도록 기능 추가

### DIFF
--- a/builder/notify_grpc.go
+++ b/builder/notify_grpc.go
@@ -84,7 +84,7 @@ func (s *GrpcSystemNotifyHandler) consumeQueue() {
 		req := proto.SendFatimaMessageRequest{}
 		req.JsonString = string(notifyItem)
 
-		for true {
+		for {
 			if s.conn == nil {
 				s.connectSaturn()
 			}


### PR DESCRIPTION
배포 등을 수행할 경우 메시지 유형이 alarm 으로 통일되어 불필요한 통보 메시지가 발생하는 경우를 개선하기 위한 수정 분입니다.
단순하게 배포 메시지만 특정 채널로 전달하게 수정하려 했으나 이럴 경우 아래와 같은 이슈가 있습니다.

1. 프로세스 셧다운 알람은 기존처럼 항상 배포 시에도 발생함, 따라서 배포 메시지만 다른 채널로 받아도 불필요한 알람을 추가로 수신 받는 행위는 여전함
2. 배포 메시지를 다른 채널로 전달 받을 경우 1번 알람으로 인해 오히려 프로세스 Panic 으로 셧다운 되었다는 오해를 줄 수 있음
3. 배포 시 프로세스 시작 / 종료 과정은 Juno에 의해 통제되고 실제 Run() / Shutdown() 행위는 fatima-core 라이브러리의 메서드를 통해 수행되므로 이를 알 방법 필요

위 이슈를 해결하고자 아래와 같이 수정했습니다.

1. 개발자에 의한 Shutdown (rostop 명령어 사용) 시 SIGUSR1 을 선 수신 받으므로 이 경우 수동 셧다운을 마크하고 alarm_ignoable 카테고리를 saturn에 전달
2. juno 에서 프로그램 구동 시 actionCategory 정보를 args 에 추가해 어디에서 이벤트가 발생했는지 알 수 있도록 함
3. actionCategory 정보를 통해 알람을 수신 받을 수 있도록 channel 지원 가능 추가
